### PR TITLE
Modal mixin definition and event binding

### DIFF
--- a/addon/components/dialog-wrapper.js
+++ b/addon/components/dialog-wrapper.js
@@ -1,9 +1,9 @@
 import Component from '@ember/component';
 import layout from '../templates/components/dialog-wrapper';
-import DialogMixin from '../mixins/dialog';
+import Overlay from '../mixins/dialog';
 
-export default Component.extend(DialogMixin, {
+export default Component.extend(Overlay, {
     layout,
     autoOpen: true,
-    'on-close': ()=>{},
+    'on-close': () => {},
 });

--- a/addon/components/modal-instance.js
+++ b/addon/components/modal-instance.js
@@ -1,8 +1,8 @@
 import Component from '@ember/component';
-import layout from '../templates/components/modal-instance';
 import { computed } from '@ember/object';
-import DialogMixin from '../mixins/dialog';
 import { getOwner } from '@ember/application';
+import Overlay from '../mixins/dialog';
+import layout from '../templates/components/modal-instance';
 
 
 export default Component.extend({
@@ -10,13 +10,16 @@ export default Component.extend({
     layout,
 
     modalName: null,
+
     isModal: computed('modalName', function() {
         let owner = getOwner(this);
         let f = owner.factoryFor('component:'+this.modalName);
-        return f.class.PrototypeMixin.mixins.includes(DialogMixin);
+        return f.class.PrototypeMixin.mixins.includes(Overlay);
     }),
+
     options:  null,
-    'on-close': ()=>{},
+    'on-close': () => {},
+
 }).reopenClass({
     positionalParams: ['modalName', 'options'],
 });

--- a/addon/mixins/dialog.js
+++ b/addon/mixins/dialog.js
@@ -1,81 +1,146 @@
 import Mixin from '@ember/object/mixin';
+import { bind } from '@ember/runloop';
+
 import ModalAttrs from './modal-attrs';
 import ModalInstance from '../components/modal-instance';
 import options from '../index';
 
-const hasDialogSupport = !options.disableDialogSupport && typeof (window.HTMLDialogElement && window.HTMLDialogElement.prototype.showModal) === 'function';
-let mixin = null;
+export const checkTargetAndElementCoords = ({ element, event }) => {
+    const el = element?.getBoundingClientRect();
+    const elTop = el?.top;
+    const elLeft = el?.left;
+    const elWidth = el?.width;
+    const elHeight = el?.height;
+    const posX = event?.clientX;
+    const posY = event?.clientY;
 
-let nativeDialog = Mixin.create(ModalAttrs, {
+    return (
+        el
+        && elTop <= posY
+        && posY <= elTop + elHeight
+        && elLeft <= posX
+        && posX <= elLeft + elWidth
+    );
+};
+
+export const Dialog = Mixin.create(ModalAttrs, {
     tagName: 'dialog',
     classNames: ['cgg-dialog'],
+
     show: true,
     autoOpen: false,
-    didInsertElement: function(){
+
+    didInsertElement: function() {
         let sup = this._super(...arguments);
-        if(this.autoOpen){
+
+        if (this.autoOpen) {
             this.openModal();
         }
+
         return sup;
     },
-    openModal: function(){
+
+    openModal: function() {
         this.element.showModal();
     },
-    closeModal: function(){
+
+    closeModal: function() {
         this.element.close();
         this['on-close']();
     },
-    click: function(evt){
-        var rect = this.element.getBoundingClientRect();
-        var isInDialog=(rect.top <= evt.clientY && evt.clientY <= rect.top + rect.height
-          && rect.left <= evt.clientX && evt.clientX <= rect.left + rect.width);
+
+    click: function(evt) {
+        var isInDialog = checkTargetAndElementCoords({
+            element: this.element,
+            event: evt,
+        });
+
         if (!isInDialog) {
             this.closeModal();
         }
     }
 });
 
-let fallbackDialog = Mixin.create(ModalAttrs, {
-    tagName: 'cgg-dialog',
-    classNames: ['cgg-dialog', 'cgg-dialog-fallback'],
+export const Modal = Mixin.create(ModalAttrs, {
+    tagName: 'modal',
+    classNames: ['cgg-modal'],
     classNameBindings: ['show:is-open'],
+
     show: false,
     autoOpen: false,
-    didInsertElement: function(){
+
+    init() {
         this._super(...arguments);
-        if(this.autoOpen){
+
+        this.boundIsClickOutsideModal = bind(this, this.isClickOutsideModal);
+        this.boundEscKeyClose = bind(this, this.escKeyClose);
+    },
+
+    didInsertElement() {
+        this._super(...arguments);
+
+        this.bindEvents();
+
+        if (this.autoOpen) {
             this.openModal();
         }
+
         return;
     },
-    openModal: function(){
+
+    willDestroyElement() {
+        this.unbindEvents();
+    },
+
+    openModal: function() {
         this.set('show', true);
     },
-    closeModal: function(){
+
+    closeModal: function() {
         this.set('show', false);
         this['on-close']();
     },
-    click: function(evt) {
 
-        let mI = this.nearestOfType(ModalInstance);
+    bindEvents() {
+        window.addEventListener('click', this.boundIsClickOutsideModal, true);
+        window.addEventListener('keydown', this.boundEscKeyClose, true);
+    },
+
+    unbindEvents() {
+        window.removeEventListener('click', this.boundIsClickOutsideModal, true);
+        window.removeEventListener('keydown', this.boundEscKeyClose, true);
+    },
+
+    isClickOutsideModal(evt) {
+        const mI = this.nearestOfType(ModalInstance);
         let isInDialog = false;
 
         if (mI.isModal) {
-            let rect = this.element.getBoundingClientRect();
-            isInDialog =(rect.top <= evt.clientY && evt.clientY <= rect.top + rect.height
-              && rect.left <= evt.clientX && evt.clientX <= rect.left + rect.width);
+            isInDialog = checkTargetAndElementCoords({
+                element: this.element,
+                event: evt,
+            });
         } else {
-            isInDialog = this.element.contains(evt.target) && this.element !== evt.target;
+            isInDialog = this.element?.contains(evt.target) || this.element === evt.target;
         }
-        
+
         if (!isInDialog) {
             this.closeModal();
         }
-    }
+    },
+
+    escKeyClose(evt) {
+        if (evt.key === 'Escape') {
+            this.closeModal();
+        }
+    },
 });
 
-export { nativeDialog, fallbackDialog };
+const OverlayType = !options.disableDialogSupport && typeof (
+    window.HTMLDialogElement
+    && window.HTMLDialogElement.prototype.showModal
+) === 'function' ? Dialog : Modal;
 
-mixin = hasDialogSupport ? nativeDialog : fallbackDialog;
+const Overlay = Mixin.create(OverlayType, {});
 
-export default mixin;
+export default Overlay;

--- a/addon/templates/components/dialog-wrapper.hbs
+++ b/addon/templates/components/dialog-wrapper.hbs
@@ -1,1 +1,3 @@
-{{yield}}
+<div>
+    {{yield}}
+</div>


### PR DESCRIPTION
- Update how the mixin is created so we can import
  either separately if required.
- Fix the close event for the custom Modal element
  as currently it can only check if a user clicked inside
  of the element.
- Add keyboard event to close on esc key, bind to window
  as keyDown on the mixin doesn't seem to work.